### PR TITLE
Add support for underscore character as non-frame-breaking space

### DIFF
--- a/js_includes/DashedSentence.js
+++ b/js_includes/DashedSentence.js
@@ -43,6 +43,11 @@ jqueryWidget: {
             }
         }
 
+        this.hideUnderscores = dget(this.options, "hideUnderscores", true);
+        if (this.hideUnderscores) {
+            this.words = $.map(this.words, function(word) { return word.replace('_', ' ') });
+        }
+
         this.mainDiv = $("<div>");
         this.element.append(this.mainDiv);
 


### PR DESCRIPTION
Linger uses the _ character as a way to specify space between words which should not be used as a break, in order to force certain words to appear together in a frame. While this type of behavior is certainly possible by specifying things like &nbsp; in ibex input, I think supporting the _ notation would be a welcome change for users familiar with Linger.
