### PR TITLE
Allow for explicit specification of line breaks

### DIFF
--- a/js_includes/DashedSentence.js
+++ b/js_includes/DashedSentence.js
@@ -11,9 +11,11 @@ jqueryWidget: {
         this.utils = this.options._utils;
         this.finishedCallback = this.options._finishedCallback;
 
-        if (typeof(this.options.s) == "string")
-            this.words = this.options.s.split(/\s+/);
-        else {
+        if (typeof(this.options.s) == "string") {
+            // replace all linebreaks (and surrounding space) with 'space-return-space'
+            var inputString = this.options.s.replace(/\s*[\r\n]\s*/, " \r ");
+            this.words = inputString.split(/[ \t]+/);
+        } else {
             assert_is_arraylike(this.options.s, "Bad value for 's' option of DashedSentence.");
             this.words = this.options.s;
         }
@@ -82,8 +84,8 @@ jqueryWidget: {
         this.resultsLines = [];
         if (this.mode == "self-paced reading") {
             // Don't want to be allocating arrays in time-critical code.
-            this.sprResults = new Array(this.words.length);
-            for (var i = 0; i < this.sprResults.length; ++i)
+            this.sprResults = [];
+            for (var i = 0; i < this.words.length; ++i)
                 this.sprResults[i] = new Array(2);
         }
         this.previousTime = null;
@@ -103,11 +105,20 @@ jqueryWidget: {
             this.blankWord = this.blankWord_dashed;
             this.showWord = this.showWord_dashed;
 
-            this.wordISpans = new Array(this.words.length); // Inner spans.
-            this.wordOSpans = new Array(this.words.length); // Outer spans.
-            this.owsnjq = new Array(this.words.length); // 'outer word spans no jQuery'.
-            this.iwsnjq = new Array(this.words.length);
+            this.wordISpans = []; // Inner spans.
+            this.wordOSpans = []; // Outer spans.
+            this.owsnjq = []; // 'outer word spans no jQuery'.
+            this.iwsnjq = []; // 'inner word spans no jQuery'.
             for (var j = 0; j < this.words.length; ++j) {
+                if ( this.words[j] == "\r" ) {
+                    this.mainDiv.append('<br/>');
+
+                    if (j <= this.stoppingPoint)
+                        this.stoppingPoint--;
+                    
+                    continue;
+                }
+
                 var ispan;
                 var ospan = $(document.createElement("span"))
                             .addClass(this.cssPrefix + 'ospan')
@@ -119,10 +130,10 @@ jqueryWidget: {
                 this.mainDiv.append(ospan);
                 if (j + 1 < this.words.length)
                     this.mainDiv.append("&nbsp; ");
-                this.wordISpans[j] = ispan;
-                this.wordOSpans[j] = ospan;
-                this.iwsnjq[j] = ispan[0];
-                this.owsnjq[j] = ospan[0];
+                this.wordISpans.push(ispan);
+                this.wordOSpans.push(ospan);
+                this.iwsnjq.push(ispan[0]);
+                this.owsnjq.push(ospan[0]);
             }
         }
 


### PR DESCRIPTION
This pull request modifies DashedSentence so experiments can specify certain points where the line will wrap. This is helpful if items are particularly long, and you want to try to nudge things so that it will wrap consistently or in an area that is not the area of interest.

Technically:
1. Words now split on non-linebreak whitespace (space and tabs) instead of all whitespace. Whitespace with returns/newlines are turned into individual "word" frames with just a return.
2. These return "words" trigger the addition of a &lt;br&gt;.
3. The return "words" are not added to the list of frames to loop through during display, i.e. the stoppingPoint should stay the same.
