### PR TITLE
Fix incorrect results output based on explicit line breaks

### DIFF
--- a/js_includes/DashedSentence.js
+++ b/js_includes/DashedSentence.js
@@ -47,7 +47,7 @@ jqueryWidget: {
 
         this.hideUnderscores = dget(this.options, "hideUnderscores", true);
         if (this.hideUnderscores) {
-            this.words = $.map(this.words, function(word) { return word.replace('_', ' ') });
+            this.words = $.map(this.words, function(word) { return word.replace(/_/g, ' ') });
         }
 
         this.mainDiv = $("<div>");


### PR DESCRIPTION
The patch I submitted before for explicit line breaks ([#2](https://github.com/addrummond/ibex/pull/2)) unfortunately messes with the output format, creating a row for the linebreak "word" and shifting all the RTs after that point. This patch fixes that.
