### PR TITLE
Question: key input saves bad results

### DIFF
--- a/js_includes/Question.js
+++ b/js_includes/Question.js
@@ -218,7 +218,7 @@ jqueryWidget: {
                             ans = t.answers[i];
                             break;
                         }
-                        else if (code == t.answers[i][0].toUpperCase().charCodeAt(0)) {
+                        else if ($.isArray(t.answers[i]) && code == t.answers[i][0].toUpperCase().charCodeAt(0)) {
                             ans = t.answers[i][1];
                             break;
                         }


### PR DESCRIPTION
When (a) autoFirstChar is false, (b) answers are in string, not array format, and (c) there is a correct answer, the code which responds to key presses incorrectly assumes that the answers are in array format, thereby basically mimicking autoFirstChar behavior, but then _storing the second character of the answer string as the result_. This results in unexpected behavior where, for answers like `['Yes', 'No']`, if a user presses "y", the answer "e" is recorded.

Suggested patch attached.
