### PR TITLE
Prevent key holding

### DIFF
--- a/js_includes/DashedSentence.js
+++ b/js_includes/DashedSentence.js
@@ -156,7 +156,9 @@ jqueryWidget: {
             this.utils.setTimeout(wordTimeout, this.wordTime);
         }
         else if (this.mode == "self-paced reading") {
-            var t = this;
+	    var keyDown = false;
+	    // keep track of pressed keys
+	    var t = this;
             // Inlining this to minimize function calls in code for updating screen after space is pressed.
 /*            function goToNext(time) {
                 t.recordSprResult(time, t.currentWord);
@@ -177,8 +179,10 @@ jqueryWidget: {
             this.safeBind($(document), 'keydown', function(e) {
                 var time = new Date().getTime();
                 var code = e.keyCode;
-
-                if (code == 32) {
+		
+		// only continue if the key was released
+                if (code == 32 && !keyDown) {
+		    keyDown = true;
                     // *** goToNext() ***
 //                    t.recordSprResult(time, t.currentWord);
                     var word = t.currentWord;
@@ -205,6 +209,12 @@ jqueryWidget: {
                     return true;
                 }
             });
+	
+	   // once the space key is released, allow its use again
+	   this.safeBind($(document), 'keyup', function(e) {
+		var code = e.keyCode;
+		keyDown = false;			
+		})		
 
             // For iPhone/iPod touch -- add button for going to next word.
             if (isIPhone) {


### PR DESCRIPTION
By keeping track whether the key has been pressed and released, we prevent the user from keeping the key down and fast-forwarding through the sentence.
 [Inspired by a more general version on StackOverflow](https://stackoverflow.com/questions/34119155/prevent-holding-enter-key-in-an-input-field)